### PR TITLE
Fix for latest version of steam (no patch necessary) and update verison manifests

### DIFF
--- a/LegacyInstaller/BSVersions.json
+++ b/LegacyInstaller/BSVersions.json
@@ -263,5 +263,10 @@
     "BSVersion": "1.19.0",
     "ManifestId": "8948172000430595334",
     "ReleaseURL": "https://steamcommunity.com/games/620980/announcements/detail/3105792342251200877"
+  },
+  {
+    "BSVersion": "1.19.1",
+    "ManifestId": "1175216641760077721",
+    "ReleaseURL": "https://steamcommunity.com/games/620980/announcements/detail/5771929045825669047"
   }
 ]

--- a/LegacyInstaller/BSVersions.json
+++ b/LegacyInstaller/BSVersions.json
@@ -245,23 +245,23 @@
     "ReleaseURL": "https://steamcommunity.com/games/620980/announcements/detail/5570379635768010184"
   },
   {
-    "BSVersion":"1.18.1",
-    "BSManifest":"8961661233382948062",
-    "ReleaseURL":"https://steamcommunity.com/games/620980/announcements/detail/2994322456166449763"
+    "BSVersion": "1.18.1",
+    "ManifestId": "8961661233382948062",
+    "ReleaseURL": "https://steamcommunity.com/games/620980/announcements/detail/2994322456166449763"
   },
   {
-    "BSVersion":"1.18.2",
-    "BSManifest":"6835596583028648427",
-    "ReleaseURL":"https://steamcommunity.com/games/620980/announcements/detail/3026974832179662032"
+    "BSVersion": "1.18.2",
+    "ManifestId": "6835596583028648427",
+    "ReleaseURL": "https://steamcommunity.com/games/620980/announcements/detail/3026974832179662032"
   },
   {
-    "BSVersion":"1.18.3",
-    "BSManifest":"6558821762131072991",
-    "ReleaseURL":"https://steamcommunity.com/games/620980/announcements/detail/3067508483705433949"
+    "BSVersion": "1.18.3",
+    "ManifestId": "6558821762131072991",
+    "ReleaseURL": "https://steamcommunity.com/games/620980/announcements/detail/3067508483705433949"
   },
   {
-    "BSVersion":"1.19.0",
-    "BSManifest":"8948172000430595334",
-    "ReleaseURL":"https://steamcommunity.com/games/620980/announcements/detail/3105792342251200877"
+    "BSVersion": "1.19.0",
+    "ManifestId": "8948172000430595334",
+    "ReleaseURL": "https://steamcommunity.com/games/620980/announcements/detail/3105792342251200877"
   }
 ]

--- a/LegacyInstaller/SteamDownloader.cs
+++ b/LegacyInstaller/SteamDownloader.cs
@@ -33,6 +33,7 @@ namespace LegacyInstaller
         {
             try { SteamPatcher.ApplyPatch(); }
             catch (SteamPatcher.PatchAlreadyAppliedException) { }
+            catch (SteamPatcher.StringNotFoundException) { }
         });
 
         private TaskCompletionSource<bool> _downloadDepotTcs;


### PR DESCRIPTION
Adds a catch to not fail when patching is actually not necessary.
updated Json to use correct name for manifest id field,
added version 1.19.1