### PR TITLE
Removed README leftovers from #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,9 @@
-# LegacyInstaller - [Download here!](https://github.com/XCraftTM/LegacyInstaller/releases/latest)
-Program to easily install legacy versions of Beat Saber  
-
-
-Fixed:
-- Beat Saber Path Getting Mechanic
-- Made Text Boxes bigger
-- More Versions
+# LegacyInstaller - [Download here!](https://github.com/Goobwabber/LegacyInstaller/releases/latest)
+Program to easily install legacy versions of Beat Saber
 
 ![Versions Preview](https://user-images.githubusercontent.com/37681398/157582172-1821fa4b-0460-4178-8d7f-d1f8e7c556a0.png)
 
 ![Window Preview](https://user-images.githubusercontent.com/72396660/162488109-875b5501-cfa7-4cb2-a5bf-4683db0b2288.png)
-
 
 ## Usage
 - Make sure steam executable directory and Beat Saber game directory are correct


### PR DESCRIPTION
There was some leftover URLs and text from the fork of XCraftTM in pull request #16. I removed and reverted them back to the original text.