### PR TITLE
Prefer to move the directory to reduce disk writing

### DIFF
--- a/LegacyInstaller/MainWindow.xaml.cs
+++ b/LegacyInstaller/MainWindow.xaml.cs
@@ -262,14 +262,22 @@ namespace LegacyInstaller
             await _steamProcess.Downloader.DownloadDepot(version.ManifestId, FileSystemChanged);
 
             // Copy files
-            this.Dispatcher.Invoke((Action)delegate { installStateLabel.Content = "Copying..."; });
-            Directory.CreateDirectory(SelectedVersionInstallDir);
-            var watcher = new FileSystemWatcher(SelectedVersionInstallDir);
-            watcher.NotifyFilter = NotifyFilters.Attributes | NotifyFilters.CreationTime | NotifyFilters.DirectoryName | NotifyFilters.FileName | NotifyFilters.LastAccess | NotifyFilters.LastWrite | NotifyFilters.Security | NotifyFilters.Size;
-            watcher.IncludeSubdirectories = true;
-            watcher.EnableRaisingEvents = true;
-            watcher.Changed += FileSystemChanged;
-            await Utilities.CopyDirectory(_steamProcess.Downloader.ContentAppDepotDir, SelectedVersionInstallDir);
+            try
+            {
+                this.Dispatcher.Invoke((Action)delegate { installStateLabel.Content = "Moving..."; });
+                Utilities.MoveDirectory(_steamProcess.Downloader.ContentAppDepotDir, SelectedVersionInstallDir);
+            }
+            catch
+            {
+                this.Dispatcher.Invoke((Action)delegate { installStateLabel.Content = "Copying..."; });
+                Directory.CreateDirectory(SelectedVersionInstallDir);
+                var watcher = new FileSystemWatcher(SelectedVersionInstallDir);
+                watcher.NotifyFilter = NotifyFilters.Attributes | NotifyFilters.CreationTime | NotifyFilters.DirectoryName | NotifyFilters.FileName | NotifyFilters.LastAccess | NotifyFilters.LastWrite | NotifyFilters.Security | NotifyFilters.Size;
+                watcher.IncludeSubdirectories = true;
+                watcher.EnableRaisingEvents = true;
+                watcher.Changed += FileSystemChanged;
+                await Utilities.CopyDirectory(_steamProcess.Downloader.ContentAppDepotDir, SelectedVersionInstallDir);
+            }
 
             // Install to steam
             this.Dispatcher.Invoke((Action)delegate { installStateLabel.Content = "Installing..."; });

--- a/LegacyInstaller/Utilities.cs
+++ b/LegacyInstaller/Utilities.cs
@@ -30,6 +30,11 @@ namespace LegacyInstaller
             catch { }
         }
 
+        public static void MoveDirectory(string sourceDir, string targetDir)
+        {
+            Directory.Move(sourceDir, targetDir);
+        }
+
         public static int Search(byte[] src, byte[] pattern)
         {
             int maxFirstCharSlot = src.Length - pattern.Length + 1;


### PR DESCRIPTION
Downloading Steam depot is a one-time use, why not just move the directory to target, so that if the source folder and target folder are in the same volume, it should save the copy time by just renaming the path, and if you're using SSD it also reduces disk writing.

Not a fan of C# so maybe you need to review the changes.